### PR TITLE
Fix names of Farfetchd and Mr mime

### DIFF
--- a/output/pokemon.json
+++ b/output/pokemon.json
@@ -11426,7 +11426,7 @@
     },
     {
         "dex": 83,
-        "name": "Farfetchd",
+        "name": "Farfetch'd",
         "animationTime": [
             1.6667,
             0.6667,
@@ -16146,7 +16146,7 @@
     },
     {
         "dex": 122,
-        "name": "Mr Mime",
+        "name": "Mr. Mime",
         "animationTime": [
             2.6667,
             0.8333,

--- a/src/core/pipeline/component.ts
+++ b/src/core/pipeline/component.ts
@@ -36,6 +36,12 @@ export interface ComponentSettings {
    * Which pipeline this component belongs to
    */
   pipeline: string;
+  /**
+   * The templateId, which the component `process` function should only
+   * be invoked.
+   * Can only be used with ComponentType.SIMPLE_MAP
+   */
+  templateId?: string;
   type?: ComponentType;
   /**
    * List of components which need to be executed in advance

--- a/src/core/pipeline/pipeline.ts
+++ b/src/core/pipeline/pipeline.ts
@@ -1,8 +1,5 @@
 import { ComponentRegister, ComponentRegistry, ComponentType } from '@core/pipeline';
-import { ItemTemplate, RootObject } from '../game_master/index';
-
-import { Component } from '@core/pipeline';
-import { IComponent } from './component';
+import { ItemTemplate, RootObject } from '../../income';
 
 /**
  * Represents a Pipeline which runs multiple components
@@ -86,7 +83,16 @@ export abstract class Pipeline {
     this.sortedComponents
       .forEach(component => {
         if (component.settings.type === ComponentType.SIMPLE_MAP) {
-          output = this.parsedInput.map((input, index) => component.component.Process(output[index] || {}, input));
+          output = this
+            .parsedInput
+            .map((input, index) => {
+              if (!component.settings.templateId || input.templateId === component.settings.templateId) {
+                return component.component.Process(output[index] || {}, input);
+              } else {
+                // Skip component processing
+                return output[index];
+              }
+            });
         } else if (component.settings.type === ComponentType.ADVANCED_MAP) {
           output = component.component.Process(output, this.parsedInput);
         }

--- a/src/core/pipeline/registry.ts
+++ b/src/core/pipeline/registry.ts
@@ -39,7 +39,8 @@ export class ComponentRegistry {
    */
   public Register(component: IComponent, settings: ComponentSettings) {
     this.components.push({
-      settings, component,
+      settings,
+      component,
       // @ts-ignore
       id: component.constructor.name
     });

--- a/src/processing/pokemon/components/explicit/farfetchd.ts
+++ b/src/processing/pokemon/components/explicit/farfetchd.ts
@@ -1,0 +1,17 @@
+import { Component, IComponent } from '@core/pipeline/component';
+import { Pokemon } from '@outcome/pokemon';
+import { Name } from '../name';
+
+@Component({
+    pipeline: 'pokemon',
+    templateId: 'V0083_POKEMON_FARFETCHD',
+    dependencies: [
+        new Name()
+    ]
+})
+export class Farfetchd implements IComponent {
+    Process(pokemon: Pokemon): Pokemon {
+        pokemon.name = 'Farfetch\'d';
+        return pokemon;
+    }
+}

--- a/src/processing/pokemon/components/explicit/index.ts
+++ b/src/processing/pokemon/components/explicit/index.ts
@@ -1,0 +1,2 @@
+import './farfetchd';
+import './mrmime';

--- a/src/processing/pokemon/components/explicit/mrmime.ts
+++ b/src/processing/pokemon/components/explicit/mrmime.ts
@@ -1,0 +1,17 @@
+import { Component, IComponent } from '@core/pipeline/component';
+import { Pokemon } from '@outcome/pokemon';
+import { Name } from '../name';
+
+@Component({
+    pipeline: 'pokemon',
+    templateId: 'V0122_POKEMON_MR_MIME',
+    dependencies: [
+        new Name()
+    ]
+})
+export class MrMime implements IComponent {
+    Process(pokemon: Pokemon): Pokemon {
+        pokemon.name = 'Mr. Mime';
+        return pokemon;
+    }
+}

--- a/src/processing/pokemon/components/index.ts
+++ b/src/processing/pokemon/components/index.ts
@@ -13,3 +13,4 @@ import './encounter/enounter';
 import './encounter/genderPercentage';
 import './camera';
 import './evolution';
+import './explicit';

--- a/test/pokemon.output.ts
+++ b/test/pokemon.output.ts
@@ -165,6 +165,12 @@ describe('Pokemon Output', () => {
                 item => expect(item.evolution.pastBranch.id, 'Hitmontop\'s only pastEvolution should be Tyrogue').to.equal('TYROGUE'),
                 item => expect(item.evolution.futureBranches, 'Hitmontop should not evolve').to.be.undefined
             ],
+            'MR_MIME': [
+                item => expect(item.name, 'MR_MIME should have the name Mr. Mime').to.equal('Mr. Mime'),
+            ],
+            'FARFETCHD': [
+                item => expect(item.name, 'FARFETCHD should have the name Farfetch\'d').to.equal('Farfetch\'d'),
+            ]
 
         };
 


### PR DESCRIPTION
# Before

See issue #2 

# Changes

- `output` Changes the name "Farfetchd" to "Farfetch'd"
- `output` Changes the name "Mr Mime" to "Mr. Mime"
- `core` Adds `templateId` for `ComponentSetttings`. `Component`s with `templateId` only gets called with items which have the set `templateId`.
- `processing` Add MrMime component
- `processing` Add Farfetchd component