### PR TITLE
feat: support legacy moves

### DIFF
--- a/output/pokemon.json
+++ b/output/pokemon.json
@@ -262,6 +262,11 @@
             {
                 "name": "Solar Beam",
                 "id": "SOLAR_BEAM"
+            },
+            {
+                "name": "Frenzy Plant",
+                "id": "FRENZY_PLANT",
+                "legacy": true
             }
         ],
         "quickMoves": [
@@ -593,6 +598,11 @@
             {
                 "name": "Overheat",
                 "id": "OVERHEAT"
+            },
+            {
+                "name": "Blast Burn",
+                "id": "BLAST_BURN",
+                "legacy": true
             }
         ],
         "quickMoves": [
@@ -925,6 +935,11 @@
             {
                 "name": "Hydro Pump",
                 "id": "HYDRO_PUMP"
+            },
+            {
+                "name": "Hydro Cannon",
+                "id": "HYDRO_CANNON",
+                "legacy": true
             }
         ],
         "quickMoves": [
@@ -2863,6 +2878,11 @@
             {
                 "name": "Wild Charge",
                 "id": "WILD_CHARGE"
+            },
+            {
+                "name": "Surf",
+                "id": "SURF",
+                "legacy": true
             }
         ],
         "quickMoves": [
@@ -16198,6 +16218,11 @@
             {
                 "name": "Swift",
                 "id": "SWIFT"
+            },
+            {
+                "name": "Last Resort",
+                "id": "LAST_RESORT",
+                "legacy": true
             }
         ],
         "quickMoves": [
@@ -16328,6 +16353,11 @@
             {
                 "name": "Aqua Tail",
                 "id": "AQUA_TAIL"
+            },
+            {
+                "name": "Last Resort",
+                "id": "LAST_RESORT",
+                "legacy": true
             }
         ],
         "quickMoves": [
@@ -16424,6 +16454,11 @@
             {
                 "name": "Thunder",
                 "id": "THUNDER"
+            },
+            {
+                "name": "Last Resort",
+                "id": "LAST_RESORT",
+                "legacy": true
             }
         ],
         "quickMoves": [
@@ -16524,6 +16559,11 @@
             {
                 "name": "Overheat",
                 "id": "OVERHEAT"
+            },
+            {
+                "name": "Last Resort",
+                "id": "LAST_RESORT",
+                "legacy": true
             }
         ],
         "quickMoves": [
@@ -17357,6 +17397,11 @@
             {
                 "name": "Blizzard",
                 "id": "BLIZZARD"
+            },
+            {
+                "name": "Hurricane",
+                "id": "HURRICANE",
+                "legacy": true
             }
         ],
         "quickMoves": [
@@ -17456,6 +17501,11 @@
             {
                 "name": "Charge Beam Fast",
                 "id": "CHARGE_BEAM_FAST"
+            },
+            {
+                "name": "Thunder Shock Fast",
+                "id": "THUNDER_SHOCK_FAST",
+                "legacy": true
             }
         ],
         "family": {
@@ -17543,6 +17593,11 @@
             {
                 "name": "Overheat",
                 "id": "OVERHEAT"
+            },
+            {
+                "name": "Sky Attack",
+                "id": "SKY_ATTACK",
+                "legacy": true
             }
         ],
         "quickMoves": [
@@ -17856,6 +17911,11 @@
             {
                 "name": "Outrage",
                 "id": "OUTRAGE"
+            },
+            {
+                "name": "Draco Meteor",
+                "id": "DRACO_METEOR",
+                "legacy": true
             }
         ],
         "quickMoves": [
@@ -18515,6 +18575,11 @@
             {
                 "name": "Earthquake",
                 "id": "EARTHQUAKE"
+            },
+            {
+                "name": "Frenzy Plant",
+                "id": "FRENZY_PLANT",
+                "legacy": true
             }
         ],
         "quickMoves": [
@@ -18842,6 +18907,11 @@
             {
                 "name": "Solar Beam",
                 "id": "SOLAR_BEAM"
+            },
+            {
+                "name": "Blast Burn",
+                "id": "BLAST_BURN",
+                "legacy": true
             }
         ],
         "quickMoves": [
@@ -21429,6 +21499,11 @@
             {
                 "name": "Thunder",
                 "id": "THUNDER"
+            },
+            {
+                "name": "Dragon Pulse",
+                "id": "DRAGON_PULSE",
+                "legacy": true
             }
         ],
         "quickMoves": [
@@ -23029,6 +23104,11 @@
             {
                 "name": "Futuresight",
                 "id": "FUTURESIGHT"
+            },
+            {
+                "name": "Last Resort",
+                "id": "LAST_RESORT",
+                "legacy": true
             }
         ],
         "quickMoves": [
@@ -23124,6 +23204,11 @@
             {
                 "name": "Foul Play",
                 "id": "FOUL_PLAY"
+            },
+            {
+                "name": "Last Resort",
+                "id": "LAST_RESORT",
+                "legacy": true
             }
         ],
         "quickMoves": [
@@ -28427,6 +28512,11 @@
             {
                 "name": "Iron Tail Fast",
                 "id": "IRON_TAIL_FAST"
+            },
+            {
+                "name": "Smack Down Fast",
+                "id": "SMACK_DOWN_FAST",
+                "legacy": true
             }
         ],
         "family": {
@@ -42102,6 +42192,11 @@
             {
                 "name": "Earthquake",
                 "id": "EARTHQUAKE"
+            },
+            {
+                "name": "Meteor Mash",
+                "id": "METEOR_MASH",
+                "legacy": true
             }
         ],
         "quickMoves": [

--- a/src/app.ts
+++ b/src/app.ts
@@ -19,6 +19,8 @@ import { ItemLocalesPipeline } from './processing/item/locales/itemLocalesPipeli
 import { AvatarCustomizationLocalesPipeline } from './processing/avatarCustomization/locales/index';
 
 const gameMaster = require('./data/GAME_MASTER.json');
+const specialGameMastersDirectory = path.resolve(__dirname, 'data/special');
+const specialGameMasters = fs.existsSync(specialGameMastersDirectory) ? fs.readdirSync(specialGameMastersDirectory).map(file => require(`./data/special/${file}`)) : [];
 const packageJson = require('../package.json');
 const POKEMON_TRANSLATIONS = require('./data/POKEMON_TRANSLATIONS.json');
 const MOVES_TRANSLATIONS = require('./data/MOVES_TRANSLATIONS.json');
@@ -69,7 +71,7 @@ console.log(`${chalk.blue('i')} Using GAME_MASTER version ${chalk.cyan(gameMaste
 
 
 const writePokemon = async () => {
-    const pokemons = await write('./output/pokemon.json', new PokemonPipeline(gameMaster), 'Pokemons');
+    const pokemons = await write('./output/pokemon.json', new PokemonPipeline(gameMaster, specialGameMasters), 'Pokemons');
     writeTranslations('pokemon.json', await new PokemonLocalesPipeline(POKEMON_TRANSLATIONS, pokemons, LOCALES), 'Pokemon Translations');
 }
 

--- a/src/processing/pokemon/pokemonPipeline.ts
+++ b/src/processing/pokemon/pokemonPipeline.ts
@@ -1,6 +1,10 @@
-import { Pipeline } from '@core/pipeline';
+import { IComponent, Pipeline } from '@core/pipeline';
 import { RootObject, ItemTemplate } from '@income';
 import { Pokemon } from '@outcome/pokemon';
+import { forEachSeries, map } from 'p-iteration';
+import * as _ from 'lodash';
+import { Util } from '@util';
+import { Identifyable } from '@core';
 
 /**
  * Represents the Pipeline which converts Game Master Pokemon related
@@ -8,9 +12,11 @@ import { Pokemon } from '@outcome/pokemon';
  */
 export class PokemonPipeline extends Pipeline {
   private readonly pokemonRegex: string = '^(V[0-9]+_POKEMON_?.*)';
+  private readonly specialMasterFiles: RootObject[];
 
-  constructor(input: RootObject) {
+  constructor(input: RootObject, special: RootObject[]) {
     super(input, 'pokemon');
+    this.specialMasterFiles = special;
   }
 
   private isPokemon(templateId: string) {
@@ -28,4 +34,67 @@ export class PokemonPipeline extends Pipeline {
     const id = item.templateId;
     return this.isPokemon(id) && !this.isNormalPokemon(id);
   }
+
+
+  public async Run(): Promise<Object[]> {
+    const pokemonData = <Pokemon[]> await super.Run();
+
+    // Handle special game master files
+    const specialInputs = await map(this.specialMasterFiles, input => input.itemTemplates.filter(p => this.isItemTemplate(p)));
+    const legacyMoveComponents = [new LegacyQuickMoves(), new LegacyCinematicMoves()];
+    await forEachSeries(specialInputs, async specialInput => {
+      await forEachSeries(specialInput, async itemTemplate => {
+        const currentPokemon = pokemonData.find(value => value.id === itemTemplate.pokemonSettings.pokemonId);
+        await forEachSeries(legacyMoveComponents, component => component.Process(currentPokemon, itemTemplate));
+      });
+    });
+
+    return pokemonData;
+  }
 }
+
+abstract class LegacyMove implements IComponent {
+  private readonly moveType: string;
+
+  protected constructor(moveType: string) {
+    this.moveType = moveType;
+  }
+
+  Process(pokemon: Pokemon, rawPokemon: ItemTemplate): Pokemon {
+    const specialMoves = _
+        .chain(rawPokemon.pokemonSettings[this.moveType])
+        .uniq()
+        .map(Util.SnakeCase2Identifyable)
+        .filter(maybeSpecialMove => pokemon[this.moveType].find(move => move.id === maybeSpecialMove.id) === undefined)
+        .map(LegacyMove.ToLegacyMove)
+        .value();
+
+    pokemon[this.moveType] = pokemon[this.moveType].concat(specialMoves);
+    return pokemon;
+  }
+
+  private static ToLegacyMove(move: Identifyable): IdentifiableMove {
+    return {
+      name: move.name,
+      id: move.id,
+      legacy: true
+    }
+  }
+}
+
+class LegacyCinematicMoves extends LegacyMove {
+  constructor() {
+    super('cinematicMoves');
+  }
+}
+
+class LegacyQuickMoves extends LegacyMove {
+  constructor() {
+    super('quickMoves');
+  }
+}
+
+export interface IdentifiableMove extends Identifyable {
+  legacy: boolean;
+}
+


### PR DESCRIPTION
quick & dirty variant of adding legacy moves by processing additional game master files from https://github.com/pokemongo-dev-contrib/pokemongo-game-master/tree/master/special

closes #5

should be improved by downloading the special files as part of the build process (for now did id manually)